### PR TITLE
Make tintColor a variable setter for NSUIImageView(AppKit)

### DIFF
--- a/Sources/NSUI/ImageView.swift
+++ b/Sources/NSUI/ImageView.swift
@@ -2,17 +2,25 @@ import SwiftUI
 
 #if canImport(AppKit)
 public extension NSImageView {
-    func tintColor(color: NSUIColor) {
-        guard
-            let selfImage = self.image
-        else { return }
-        let image = NSImage(size: selfImage.size, flipped: false) { (rect) -> Bool in
-            color.set()
-            rect.fill()
-            selfImage.draw(in: rect, from: NSRect(origin: .zero, size: selfImage.size), operation: .destinationIn, fraction: 1.0)
-            return true
+    var tintColor: NSUIColor {
+        @available(*, unavailable)
+        get {
+            fatalError("Unavailable")
         }
-        self.image = image
+        set {
+            guard
+                let selfImage = self.image
+            else {
+                return
+            }
+            let image = NSImage(size: selfImage.size, flipped: false) { (rect) -> Bool in
+                newValue.set()
+                rect.fill()
+                selfImage.draw(in: rect, from: NSRect(origin: .zero, size: selfImage.size), operation: .destinationIn, fraction: 1.0)
+                return true
+            }
+            self.image = image
+        }
     }
 }
 #endif


### PR DESCRIPTION
This is to align with the way UIKit is changing the tintColor and prevent conditional compilation.